### PR TITLE
feat: validate and mark the move

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -1,9 +1,0 @@
-type Cell = "X" | "O" | null;
-
-type Board = {
-  size: number;
-  cells: Cell[][];
-  indexOffset: number;
-};
-
-export type { Board };

--- a/src/createBoard.ts
+++ b/src/createBoard.ts
@@ -1,4 +1,4 @@
-import type { Board } from "./board.js";
+import type { Board } from "./types";
 
 type Param = {
   size: number;
@@ -11,6 +11,7 @@ const createBoard = ({ size, indexOffset }: Param): Board => {
   return {
     size,
     cells,
+    status: "NotOver",
     indexOffset,
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,32 +1,50 @@
 import { createBoard } from "./createBoard.js";
+import { markMove } from "./markMove.js";
+import { otherPlayer } from "./otherPlayer.js";
 import { printBoard } from "./printBoard.js";
-import prompt from "./prompt.js";
+import { prompt } from "./prompt.js";
+import type { Coord, Player } from "./types.js";
+import { validateMove } from "./validateMove.js";
 
 console.log("Welcome to Tic Tac Toe!");
 
 const boardSize = 3;
 const indexOffset = 1;
 let roundCount = 0;
+let currentPlayer: Player = "X";
 
 while (true) {
   roundCount += 1;
-
   console.log(`Round ${roundCount}!`);
 
+  // Reset board
   const board = createBoard({ size: boardSize, indexOffset });
   const maxTurn = board.size * board.size;
   let turnCount = 0;
 
   do {
-    turnCount += 1;
-
+    console.log("\n");
     printBoard({ board });
 
+    turnCount += 1;
     console.log(`Turn: ${turnCount}`);
 
-    const answer = await prompt.question("What is your next move?\n");
+    // Ask for the next move.
+    while (true) {
+      const input = await prompt.question(
+        `Player ${currentPlayer}, make a move!\n`,
+      );
 
-    console.log(`Move accepted: ${answer}`);
+      const { valid, move, error } = validateMove({ input, board });
+
+      if (valid) {
+        markMove({ move: move as Coord, mover: currentPlayer, board });
+        currentPlayer = otherPlayer({ currentPlayer });
+        break;
+      }
+
+      console.log(error);
+    }
   } while (turnCount < maxTurn);
 
   const answer = await prompt.question(

--- a/src/markMove.ts
+++ b/src/markMove.ts
@@ -1,0 +1,13 @@
+import type { Board, Coord, Player } from "./types";
+
+type Param = {
+  move: Coord;
+  mover: Player;
+  board: Board;
+};
+
+const markMove = ({ move, mover, board }: Param) => {
+  board.cells[move.row][move.col] = mover;
+};
+
+export { markMove };

--- a/src/otherPlayer.ts
+++ b/src/otherPlayer.ts
@@ -1,0 +1,11 @@
+import type { Player } from "./types";
+
+type Param = {
+  currentPlayer: Player;
+};
+
+const otherPlayer = ({ currentPlayer }: Param) => {
+  return currentPlayer === "X" ? "O" : "X";
+};
+
+export { otherPlayer };

--- a/src/printBoard.ts
+++ b/src/printBoard.ts
@@ -1,6 +1,6 @@
 import { Table } from "console-table-printer";
 import type { ColumnOptionsRaw } from "console-table-printer/dist/src/models/external-table.js";
-import type { Board } from "./board.js";
+import type { Board } from "./types";
 
 type CreateColumnDefsParam = {
   board: Board;

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -6,4 +6,4 @@ const prompt = readlinePromises.createInterface({
   prompt: "",
 });
 
-export default prompt;
+export { prompt };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,19 @@
+type Player = "X" | "O";
+
+type Cell = Player | null;
+
+type Status = "XWon" | "OWon" | "Draw" | "NotOver";
+
+type Board = {
+  size: number;
+  cells: Cell[][];
+  status: Status;
+  indexOffset: number;
+};
+
+type Coord = {
+  row: number;
+  col: number;
+};
+
+export type { Board, Coord, Player };

--- a/src/validateMove.ts
+++ b/src/validateMove.ts
@@ -1,0 +1,50 @@
+import type { Board, Coord } from "./types";
+
+type Param = {
+  input: string;
+  board: Board;
+};
+
+type ValidateMoveResult = {
+  valid: boolean;
+  move?: Coord;
+  error?: string;
+};
+
+const validateMove = ({ input, board }: Param): ValidateMoveResult => {
+  const hasTwoIntsOnly = /^\s*\d+\s+\d+\s*$/.test(input);
+
+  if (!hasTwoIntsOnly) {
+    return {
+      valid: false,
+      error:
+        "Please give a number for X and a number for Y, separated by a space.",
+    };
+  }
+
+  const [rowToken, colToken] = input.trim().split(/\s+/);
+
+  const rowIndex = Number.parseInt(rowToken) - board.indexOffset;
+  const colIndex = Number.parseInt(colToken) - board.indexOffset;
+
+  const areIndicesWithinRange =
+    rowIndex >= 0 &&
+    rowIndex < board.size &&
+    colIndex >= 0 &&
+    colIndex < board.size;
+
+  if (!areIndicesWithinRange) {
+    return {
+      valid: false,
+      error: "Please enter a coordinate within the board!",
+    };
+  }
+
+  if (board.cells[rowIndex][colIndex] !== null) {
+    return { valid: false, error: "Alas, that spot is already taken!" };
+  }
+
+  return { valid: true, move: { row: rowIndex, col: colIndex } };
+};
+
+export { validateMove };


### PR DESCRIPTION
When a player enters their next move, sanitize it and validate these criteria:
1. The player entered a valid coordinate e.g. `2 3`, not something like `some other input`
2. The coordinate is within the range of the board. For a 3 x 3 board, `4 1` would be invalid.
3. The coordinate is not already marked.

If valid, the move will be marked on the board.
If not, the explanation of why the move is invalid will be displayed:

![Screenshot 2025-06-06 at 6 10 04 PM](https://github.com/user-attachments/assets/3359c616-1c69-487e-a463-095ac0d8cba8)
