### PR TITLE
fix: set col index from x, row index from y

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { otherPlayer } from "./otherPlayer.js";
 import { printBoard } from "./printBoard.js";
 import { prompt } from "./prompt.js";
 import type { Coord, Player } from "./types.js";
-import { validateMove } from "./validateMove.js";
+import { validateMoveInput } from "./validateMoveInput.js";
 
 console.log("Welcome to Tic Tac Toe!");
 
@@ -35,7 +35,7 @@ while (true) {
         `Player ${currentPlayer}, make a move!\n`,
       );
 
-      const { valid, move, error } = validateMove({ input, board });
+      const { valid, move, error } = validateMoveInput({ input, board });
 
       if (valid) {
         markMove({ move: move as Coord, mover: currentPlayer, board });

--- a/src/validateMoveInput.ts
+++ b/src/validateMoveInput.ts
@@ -11,7 +11,7 @@ type ValidateMoveResult = {
   error?: string;
 };
 
-const validateMove = ({ input, board }: Param): ValidateMoveResult => {
+const validateMoveInput = ({ input, board }: Param): ValidateMoveResult => {
   const hasTwoIntsOnly = /^\s*\d+\s+\d+\s*$/.test(input);
 
   if (!hasTwoIntsOnly) {
@@ -22,7 +22,8 @@ const validateMove = ({ input, board }: Param): ValidateMoveResult => {
     };
   }
 
-  const [rowToken, colToken] = input.trim().split(/\s+/);
+  // X represents column index, Y represents row index.
+  const [colToken, rowToken] = input.trim().split(/\s+/);
 
   const rowIndex = Number.parseInt(rowToken) - board.indexOffset;
   const colIndex = Number.parseInt(colToken) - board.indexOffset;
@@ -47,4 +48,4 @@ const validateMove = ({ input, board }: Param): ValidateMoveResult => {
   return { valid: true, move: { row: rowIndex, col: colIndex } };
 };
 
-export { validateMove };
+export { validateMoveInput };


### PR DESCRIPTION
In https://github.com/chohanbin/tic-tac-toe-cli/pull/4, I introduced a bug.
I wanted an input `1 3` to correspond to `X Y` value.
I assumed X would mean row index (since row is horizontal), and Y would mean column index (since column is vertical).
However, the opposite is correct. X corresponds to which column to select, and Y corresponds to which row to select.

Before PR

![Screenshot 2025-06-09 at 6 12 45 PM](https://github.com/user-attachments/assets/c69e3f70-cfdc-428d-816d-708d6226fbbd)


After PR

![Screenshot 2025-06-09 at 6 12 04 PM](https://github.com/user-attachments/assets/86982680-2c26-405f-a19f-364a141e0794)
